### PR TITLE
RCA-38 protocol

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,13 @@ Philips RC-6 Protocol
 
     irgen -i rc6 -d 16 -1 0 -o raw
 
+RCA RCA-38 Protocol
+---------------------
+
+.. code-block:: bash
+
+     irgen -i rca38 -d 15 -1 0 -o raw
+
 
 Raw
 ---

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -15,3 +15,10 @@ def test_broadlink_decode_encode():
     raw  = list(irgen.gen_raw_from_broadlink_base64(data))
     data2 = bytes(irgen.gen_broadlink_base64_from_raw(raw))
     assert data == data2
+
+def test_rca38_decode_encode():
+    """
+    data was generated with IrScrutinizer-2.2.6 device 12, OBC 123
+    """
+    data = [+3680,-3680,+460,-1840,+460,-1840,+460,-920,+460,-920,+460,-920,+460,-1840,+460,-1840,+460,-1840,+460,-1840,+460,-920,+460,-1840,+460,-1840,+460,-920,+460,-920,+460,-1840,+460,-1840,+460,-1840,+460,-920,+460,-920,+460,-920,+460,-920,+460,-1840,+460,-920,+460,-920,+460,-7360]
+    assert data == list(irgen.gen_raw_general('rca38', 12, -1, 123))


### PR DESCRIPTION
I am not sure if you accept PR, but here is one. It adds RCA-38 protocol. This is used by TCL TV's. 
I did not test it with real devices yet, but IrScrutinizer seems to recognise the generated code alright.

This coding accepts devices  0-15 and OBC 0-255

The encoding is quite simple
     device (4 bits)  OBC (8 bits)  device complement (4 bits) OBC complement (8 bits)